### PR TITLE
Add scan_interval config variable to miflora

### DIFF
--- a/source/_integrations/miflora.markdown
+++ b/source/_integrations/miflora.markdown
@@ -108,6 +108,11 @@ go_unavailable_timeout:
   required: false
   default: 7200
   type: integer
+scan_interval:
+  description: "Sensor scan interval in seconds"
+  required: false
+  default: 1200
+  type: integer
 {% endconfiguration %}
 
 <div class='note warning'>
@@ -129,6 +134,7 @@ sensor:
     force_update: true
     median: 3
     go_unavailable_timeout: 43200
+    scan_interval: 1200
     monitored_conditions:
       - moisture
       - light


### PR DESCRIPTION
## Proposed change
Add documentation for new optional miflora configuration variable scan_interval 



## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/67754
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [x] The documentation follows the Home Assistant documentation [standards][].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
